### PR TITLE
Update CI with more specifics

### DIFF
--- a/tier1_standards/ci.md
+++ b/tier1_standards/ci.md
@@ -11,11 +11,14 @@ CI's automated building and testing allows developers to:
 - Avoid long integration processes for large code changes
 - Test changes before merging to avoid breaking the code base
 - Find bugs early in the development
+- Easily test the installation of their package
 
 ## Options for this standard
 For a summary of the different CI options available at STScI, see the STScI Style Guide on CI [here](https://github.com/spacetelescope/style-guides/blob/master/guides/python-testing.md/#continuous-integration)
 
 ## How to apply this standard
+The existence of unit tests is highly encouraged as part of this standard, but not required. Since CI also tests the installation of your package, it can be set up without the existence of any unit tests.
+
 See a guide on how to set up multiple CI options from the [STScI Training Library](https://spacetelescope.github.io/training-library/ci_testing.html#introduction-to-continuous-integration)
 
 ## Useful Links

--- a/tier1_standards/ci.md
+++ b/tier1_standards/ci.md
@@ -17,7 +17,7 @@ CI's automated building and testing allows developers to:
 For a summary of the different CI options available at STScI, see the STScI Style Guide on CI [here](https://github.com/spacetelescope/style-guides/blob/master/guides/python-testing.md/#continuous-integration)
 
 ## How to apply this standard
-The existence of unit tests is highly encouraged as part of this standard, but not required. Since CI also tests the installation of your package, it can be set up without the existence of any unit tests.
+The existence of unit tests is highly encouraged as part of this standard, but not required. Since CI also tests package installation, it can be set up without the existence of any unit tests.
 
 See a guide on how to set up multiple CI options from the [STScI Training Library](https://spacetelescope.github.io/training-library/ci_testing.html#introduction-to-continuous-integration)
 

--- a/tier2_standards/README.md
+++ b/tier2_standards/README.md
@@ -10,6 +10,7 @@ The software standards identified to be met as part of the "second tier" are:
 - Software Must Enforce Coding Standards
 - Software Must Have Backup Maintainers
 - Software Must Have Documented Reasoning For Releases
+- Software Must Have Some Test Coverage
 - Software Must Use Continuous Deployment
 - Software Must Use an Automated Dependency Controller
 - Software Must Have Documented Citation Information


### PR DESCRIPTION
Explicitly state that the CI requirement in tier 1 does not include the existence of unit tests, and instead include tests in the tier 2 standards.