### PR TITLE
Remove references to astroconda

### DIFF
--- a/tier1_standards/conda_or_pip.md
+++ b/tier1_standards/conda_or_pip.md
@@ -10,7 +10,6 @@ While packaging the software and having it available as an open source repositor
 
 ## Options for this standard
 - PyPi (the Python Package Index; this must be a Python package)
-- Conda via Astroconda (not language dependent)
 - Conda via Conda-Forge (not language dependent)
 
 ## How to apply this standard
@@ -22,13 +21,9 @@ To add your package to PyPi:
 - See these [instructions from Python](https://packaging.python.org/tutorials/packaging-projects/#generating-distribution-archives)
 - Note that these tell you how to upload the package to Test PyPi as a check before uploading it to PyPi. We agree and recommend you install your package from Test PyPi and run your tests locally before determining if you're ready to upload to PyPi.
 
-To add your package to Astroconda:
-- See their [contributing guide](https://astroconda.readthedocs.io/en/latest/contributing.html#adding-a-recipe-to-astroconda-contrib).
-
 To add your package to Conda-Forge:
 - See their [contributing guide](https://conda-forge.org/docs/maintainer/adding_pkgs.html#contributing-packages).
 
 ## Useful Links
 - [Installing a package from `pip`](https://packaging.python.org/tutorials/installing-packages/)
-- [Installing a package from Astroconda](https://astroconda.readthedocs.io/en/latest/index.html)
 - [Installing a package from Conda-Forge](https://conda-forge.org/docs/user/introduction.html#how-can-i-install-packages-from-conda-forge)

--- a/tier2_standards/release_procedure.md
+++ b/tier2_standards/release_procedure.md
@@ -16,7 +16,7 @@ Adopting a consistent, documented release procedure has several benefits:
 
 ## Options for this standard
 
-Teams may opt to create their own custom release procedure, reference an existing release procedure, or tweak as necessary one of the two examples provided below.  One example releases on `pypi` and the other on `astroconda`.
+Teams may opt to create their own custom release procedure, reference an existing release procedure, or tweak as necessary the example provided below, which uses `pypi`:
 
 Example using **PyPI**:
 
@@ -74,71 +74,6 @@ To upload the new tagged version of the software to PyPI, run the following:
   --skip-existing dist/*
 ```
 
-Example using **astroconda**:
-
-```
-The <project> team performs a software release at <some occasion>. We employ the following procedure for creating
-a new release:
-
-    1. Create a new branch for changes related to the version release procedure
-    2. Update appropriate version numbers in <locations that store the version number>,
-    3. Update the release notes
-    4. Open, review, and merge pull request with the release procedure changes
-    5. Create a new tag/release on GitHub/GitLab
-    6. Upload new version of software to astroconda
-
-Detailed instructions for performing a release are given below:
-
-1. Create a new branch for changes related to the version release procedure
-
-Make sure that your local version of the <develop branch> is up-to-date. A new branch with the naming convention
-vx.y.z should be opened off of the <develop branch>, where vx.y.z is the version number of the release
-(e.g. v0.4.1). This branch should be used for the changes described in the rest of this document.
-
-2. Update the version number in <locations that store the version number>
-
-<Update all locations of hard-coded version numbers. For example, the VERSION variable in setup.py should be
-updated to the new version number, using the x.y.z convention.>
-
-3. Update the release notes
-
-In <location of release notes>, write a concise but detailed description of all of the notable changes that have
-occurred since the last release. One way to acquire this information is to scroll through the commit history of
-the project, and look for commits in which a pull request was merged.
-
-4. Open, review, and merge pull requests with the release procedure changes
-
-Once you've committed the changes from (2), (3), and (4) in your branch, push your branch to GitHub/GitLab using
-the upstream remote, open two pull requests: one that points to the production branch (e.g. main), and one
-that points to <develop branch>. Assign reviewers. Either you or the reviewer should eventually merge these pull
-requests.
-
-5. Create a new tag/release on GitHub/GitLab
-
-Once the pull request into the production branch from (5) has been merged, click on the releases button on the
-main page of the repository, then hit the "Draft a new release button". The "Tag version" should be the version
-number of the release, the "Target" should be the production branch, the "Release title" should (also) be the
-version number of the release, and the "Description" should match that of the changelog entry in (4). Once all
-of that information is added, hit the big green "Publish" release button.
-
-6. Upload new version of software to astroconda
-
-To upload the new tagged version of the software to astroconda, run the following:
-
-- cd astroconda-contrib
-- git checkout -tb update-<my_package> main
-- Open <my_package>/meta.yaml in text editor
-- Modify {% set version = '<version>' %}, close, and save
-- Run conda build -c http://ssb.stsci.edu/astroconda --skip-existing --python=<python_version> <my_package>
-  and verify it passes without error
-- git add <my_package>/meta.yaml
-- git commit -m 'Updated <my_package> <old_version> -> <new_version>'
-- git push origin update-<my_package>
-- In a broswer, navigate to  https://github.com/<your_accnount>/astroconda-contrib/tree/update-<my_package>
-- Click the “New pull request” button
-- Fill out the pull request form
-- Click the green “Create pull request” button
-```
 
 ## How to apply this standard
 


### PR DESCRIPTION
This PR removes references to `astroconda`, since it will eventually be unsupported.  The documentation still contains materials for using `conda-forge`.